### PR TITLE
build.sh: sh(1) works just fine, so why use bash(1)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Check for sbcl
 which sbcl || { echo "Please install SBCL to build sigil."; exit 1; }


### PR DESCRIPTION
bash(1) is not installed by default on quite a few UNIX based operating systems, e.g. *BSDs, or Debian minimal, but sh(1) is always installed. `build.sh` works just fine with `sh`.

And in *BSDs, `bash` is usually not installed as `/bin/bash`, so ideal way to create `bash` scripts is to have `#!/usr/bin/env bash` in shebang line.

HTH
