### PR TITLE
Expose executable in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Usage
 Installation
 ------------
 
-Run 'make' or './build.sh' to compile sigil. It requires sbcl (or
-maybe some other Common Lisp but I haven't tried) to be installed,
-which you can grab from http://www.sbcl.org/platform-table.html, or
-through something like 'apt-get install sbcl'.
+    $ npm install -g sigil-cli
 
-You can 'npm install sigil-cli' (note the underscore) locally into
-node_modules; the -g option doesn't work yet.
+This will automatically try to compile the executable which can then
+be run with the `sigil` command. It requires from the system:
+
+- SBCL (or some other Common Lisp implementation, untested)
+- `make` for building the executable.
+- `wget` for fetching dependencies.
 
 Load
 ----

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Installation
 This will automatically try to compile the executable which can then
 be run with the `sigil` command. It requires from the system:
 
-- SBCL (or some other Common Lisp implementation, untested)
+- [SBCL](http://sbcl.org/) (or some other Common Lisp implementation,
+  but Sigil uses this by default)
 - `make` for building the executable.
 - `wget` for fetching dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sigil-cli",
-    "version": "1.0.4",
+    "version": "1.0.7",
     "description": "Sigil is a Parenscript to Javascript command line compiler and REPL.",
     "bin": "./sigil",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Sigil is a Parenscript to Javascript command line compiler and REPL.",
     "bin": "./sigil",
     "scripts": {
-        "install": "make",
+        "preinstall": "make",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "sigil-cli",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Sigil is a Parenscript to Javascript command line compiler and REPL.",
-    "main": "sigil",
+    "bin": "./sigil",
     "scripts": {
         "install": "make",
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
It was pointless to use the `main` field because it's not a CJS module that can be required from Node.js land. Instead, try to use `bin` for exposing the executable.
